### PR TITLE
fix: FutureWarning in coslat check

### DIFF
--- a/xeofs/xarray/eof.py
+++ b/xeofs/xarray/eof.py
@@ -107,7 +107,9 @@ class EOF(_BaseEOF):
         norm : bool = False,
         weights : Optional[Union[xr.DataArray, str]] = None
     ):
-        use_coslat = True if weights == 'coslat' else False
+        use_coslat = (
+            True if (isinstance(weights, str) and weights == 'coslat') else False
+        )
 
         self._tf = _MultiDataArrayTransformer()
         X = self._tf.fit_transform(X, dim=dim, coslat=use_coslat)

--- a/xeofs/xarray/mca.py
+++ b/xeofs/xarray/mca.py
@@ -71,8 +71,12 @@ class MCA(_BaseMCA):
         weights_X : Optional[Union[str, DataArrayList]] = None,
         weights_Y : Optional[Union[str, DataArrayList]] = None
     ):
-        use_coslat_X = True if weights_X == 'coslat' else False
-        use_coslat_Y = True if weights_Y == 'coslat' else False
+        use_coslat_X = (
+            True if (isinstance(weights_X, str) and weights_X == 'coslat') else False
+        )
+        use_coslat_Y = (
+            True if (isinstance(weights_Y, str) and weights_Y == 'coslat') else False
+        )
 
         self._tfx = _MultiDataArrayTransformer()
         self._tfy = _MultiDataArrayTransformer()

--- a/xeofs/xarray/rock_pca.py
+++ b/xeofs/xarray/rock_pca.py
@@ -24,7 +24,9 @@ class ROCK_PCA(_BaseROCK_PCA):
         norm: bool = False,
         weights: Optional[DataArray] = None,
     ):
-        use_coslat = True if weights == 'coslat' else False
+        use_coslat = (
+            True if (isinstance(weights, str) and weights == 'coslat') else False
+        )
 
         self._tf = _MultiDataArrayTransformer()
         X = self._tf.fit_transform(X, dim=dim, coslat=use_coslat)


### PR DESCRIPTION
One more small one. When supplying a custom array to `weights` in the `xarray` interface, we get:

```
FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  use_coslat = True if weights == 'coslat' else False
```

This just checks if `weights` is a `str` before trying to compare so we don't get the warning.