### PR TITLE
fix: correct MCA scores and SCF

### DIFF
--- a/tests/models/test_complex_mca.py
+++ b/tests/models/test_complex_mca.py
@@ -23,12 +23,35 @@ def test_complex_mca_initialization():
 def test_complex_mca_fit(mca_model, mock_data_array, dim):
     mca_model.fit(mock_data_array, mock_data_array, dim)
     assert mca_model._singular_values is not None
-    assert mca_model._explained_variance is not None
-    assert mca_model._squared_total_variance is not None
+    assert mca_model._explained_covariance is not None
+    assert mca_model._total_squared_covariance is not None
     assert mca_model._singular_vectors1 is not None
     assert mca_model._singular_vectors2 is not None
     assert mca_model._norm1 is not None
     assert mca_model._norm2 is not None
+
+
+@pytest.mark.parametrize('dim', [
+    (('time',)),
+    (('lat', 'lon')),
+    (('lon', 'lat')),
+])
+def test_covariance_fraction(mca_model, mock_data_array, dim):
+    mca_model.fit(mock_data_array, mock_data_array, dim)
+    covariance_fraction = mca_model.covariance_fraction()
+    assert isinstance(covariance_fraction, xr.DataArray)
+
+
+@pytest.mark.parametrize('dim', [
+    (('time',)),
+    (('lat', 'lon')),
+    (('lon', 'lat')),
+])
+def test_squared_covariance_fraction(mca_model, mock_data_array, dim):
+    mca_model.fit(mock_data_array, mock_data_array, dim)
+    squared_covariance_fraction = mca_model.squared_covariance_fraction()
+    assert isinstance(squared_covariance_fraction, xr.DataArray)
+
 
 
 @pytest.mark.parametrize('dim', [

--- a/tests/models/test_complex_mca_rotator.py
+++ b/tests/models/test_complex_mca_rotator.py
@@ -4,23 +4,23 @@ import xarray as xr
 from dask.array import Array as DaskArray   # type: ignore
 
 # Import the classes from your modules
-from xeofs.models import MCA, MCARotator
+from xeofs.models import ComplexMCA, ComplexMCARotator
 
 @pytest.fixture
 def mca_model(mock_data_array, dim):
-    mca = MCA(n_modes=5)
+    mca = ComplexMCA(n_modes=5)
     mca.fit(mock_data_array, mock_data_array, dim)
     return mca
 
 @pytest.fixture
 def mca_model_delayed(mock_dask_data_array, dim):
-    mca = MCA(n_modes=5)
+    mca = ComplexMCA(n_modes=5)
     mca.fit(mock_dask_data_array, mock_dask_data_array, dim)
     return mca
 
 
 def test_mcarotator_init():
-    mca_rotator = MCARotator(n_modes=2)
+    mca_rotator = ComplexMCARotator(n_modes=2)
     assert mca_rotator._params['n_modes'] == 2
     assert mca_rotator._params['power'] == 1
     assert mca_rotator._params['max_iter'] == 1000
@@ -34,7 +34,7 @@ def test_mcarotator_init():
     (('lon', 'lat')),
 ])
 def test_mcarotator_fit(mca_model):
-    mca_rotator = MCARotator(n_modes=2)
+    mca_rotator = ComplexMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
 
     assert hasattr(mca_rotator, "_rotation_matrix")
@@ -47,12 +47,11 @@ def test_mcarotator_fit(mca_model):
     (('lon', 'lat')),
 ])
 def test_mcarotator_transform(mca_model, mock_data_array):
-    mca_rotator = MCARotator(n_modes=2)
+    mca_rotator = ComplexMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
     
-    projections = mca_rotator.transform(data1=mock_data_array, data2=mock_data_array)
-    
-    assert len(projections) == 2
+    with pytest.raises(NotImplementedError):
+        projections = mca_rotator.transform(data1=mock_data_array, data2=mock_data_array, mode=slice(1,3))
 
 
 @pytest.mark.parametrize('dim', [
@@ -61,7 +60,7 @@ def test_mcarotator_transform(mca_model, mock_data_array):
     (('lon', 'lat')),
 ])
 def test_mcarotator_inverse_transform(mca_model):
-    mca_rotator = MCARotator(n_modes=2)
+    mca_rotator = ComplexMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
     
     reconstructed_data = mca_rotator.inverse_transform(mode=slice(1,3))
@@ -93,14 +92,14 @@ def test_squared_covariance_fraction(mca_model, mock_data_array, dim):
 
 
 
-@pytest.mark.parametrize('dim', [
-    (('time',)),
-    (('lat', 'lon')),
-    (('lon', 'lat')),
-])
-def test_mcarotator_compute(mca_model_delayed):
-    '''Test the compute method of the MCARotator class.'''
-    pass
+# @pytest.mark.parametrize('dim', [
+#     (('time',)),
+#     (('lat', 'lon')),
+#     (('lon', 'lat')),
+# ])
+# def test_mcarotator_compute(mca_model_delayed):
+#     '''Test the compute method of the ComplexMCARotator class.'''
+#     pass
     # NOTE: This test takes a long time to run though it should not. Running the same example
     # in a separate file is much faster. I don't have a clue why this is the case but for the moment
     # I will leave it as is but deactivate the test. 

--- a/tests/models/test_mca.py
+++ b/tests/models/test_mca.py
@@ -23,8 +23,8 @@ def test_mca_initialization():
 def test_mca_fit(mca_model, mock_data_array, dim):
     mca_model.fit(mock_data_array, mock_data_array, dim)
     assert mca_model._singular_values is not None
-    assert mca_model._explained_variance is not None
-    assert mca_model._squared_total_variance is not None
+    assert mca_model._explained_covariance is not None
+    assert mca_model._total_squared_covariance is not None
     assert mca_model._singular_vectors1 is not None
     assert mca_model._singular_vectors2 is not None
     assert mca_model._norm1 is not None
@@ -114,9 +114,20 @@ def test_singular_values(mca_model, mock_data_array, dim):
 ])  
 def test_explained_variance(mca_model, mock_data_array, dim):
     mca_model.fit(mock_data_array, mock_data_array, dim)
-    explained_variance = mca_model.explained_variance()
-    assert isinstance(explained_variance, xr.DataArray)
+    explained_covariance = mca_model.explained_covariance()
+    assert isinstance(explained_covariance, xr.DataArray)
 
+
+@pytest.mark.parametrize('dim', [
+    (('time',)),
+    (('lat', 'lon')),
+    (('lon', 'lat')),
+])
+def test_covariance_fraction(mca_model, mock_data_array, dim):
+    mca_model.fit(mock_data_array, mock_data_array, dim)
+    covariance_fraction = mca_model.covariance_fraction()
+    assert isinstance(covariance_fraction, xr.DataArray)
+    
 
 @pytest.mark.parametrize('dim', [
     (('time',)),
@@ -189,10 +200,10 @@ def test_heterogeneous_patterns(mca_model, mock_data_array, dim):
 def test_compute(mca_model, mock_dask_data_array, dim):
     mca_model.fit(mock_dask_data_array, mock_dask_data_array, (dim))
     assert isinstance(mca_model._singular_values.data, DaskArray)
-    assert isinstance(mca_model._explained_variance.data, DaskArray)
+    assert isinstance(mca_model._explained_covariance.data, DaskArray)
     mca_model.compute()
     assert isinstance(mca_model._singular_values.data, np.ndarray)
-    assert isinstance(mca_model._explained_variance.data, np.ndarray)
+    assert isinstance(mca_model._explained_covariance.data, np.ndarray)
 
 
 

--- a/xeofs/models/decomposer.py
+++ b/xeofs/models/decomposer.py
@@ -148,8 +148,9 @@ class CrossDecomposer(Decomposer):
         # Assuming that X1 and X2 are centered
         cov_matrix = xr.dot(X1.conj(), X2, dims='sample') / (X1.sample.size - 1)
 
-        # Compute squared total variance
-        self.squared_total_variance_ = (abs(cov_matrix)**2).sum().compute()
+        # Compute (squared) total variance
+        self.total_covariance_ = (abs(cov_matrix)).sum().compute()
+        self.total_squared_covariance_ = (abs(cov_matrix)**2).sum().compute()
 
         is_dask = True if isinstance(cov_matrix.data, DaskArray) else False
         is_complex = True if np.iscomplexobj(cov_matrix.data) else False

--- a/xeofs/models/decomposer.py
+++ b/xeofs/models/decomposer.py
@@ -149,7 +149,7 @@ class CrossDecomposer(Decomposer):
         cov_matrix = xr.dot(X1.conj(), X2, dims='sample') / (X1.sample.size - 1)
 
         # Compute squared total variance
-        self.squared_total_variance_ = (cov_matrix**2).sum().compute()
+        self.squared_total_variance_ = (abs(cov_matrix)**2).sum().compute()
 
         is_dask = True if isinstance(cov_matrix.data, DaskArray) else False
         is_complex = True if np.iscomplexobj(cov_matrix.data) else False

--- a/xeofs/models/mca.py
+++ b/xeofs/models/mca.py
@@ -61,23 +61,24 @@ class MCA(_BaseCrossModel):
         # singular_values_pca is equivalent to the singular values obtained
         # when performing PCA of X1 or X2.
         self._singular_values = decomposer.singular_values_
-        self._explained_variance = decomposer.singular_values_  # actually covariance
-        self._squared_total_variance = decomposer.squared_total_variance_
-        self._squared_covariance_fraction = self._explained_variance**2 / self._squared_total_variance
+        self._explained_covariance = decomposer.singular_values_  # actually covariance
+        self._total_covariance = decomposer.total_covariance_
+        self._total_squared_covariance = decomposer.total_squared_covariance_
+        self._squared_covariance_fraction = self._explained_covariance**2 / self._total_squared_covariance
         self._singular_values_pca = np.sqrt(self._singular_values * (self.data1.shape[0] - 1))
         self._singular_vectors1 = decomposer.singular_vectors1_
         self._singular_vectors2 = decomposer.singular_vectors2_
         self._norm1 = np.sqrt(self._singular_values)
         self._norm2 = np.sqrt(self._singular_values)
 
-        self._explained_variance.name = 'explained_variance'
-        self._squared_total_variance.name = 'squared_total_variance'
+        self._explained_covariance.name = 'explained_covariance'
+        self._total_squared_covariance.name = 'total_squared_covariance'
         self._squared_covariance_fraction.name = 'squared_covariance_fraction'
         self._norm1.name = 'left_norm'
         self._norm2.name = 'right_norm'
 
         # Project the data onto the singular vectors
-        sqrt_expvar = np.sqrt(self._explained_variance)
+        sqrt_expvar = np.sqrt(self._explained_covariance)
         self._scores1 = xr.dot(self.data1, self._singular_vectors1) / sqrt_expvar
         self._scores2 = xr.dot(self.data2, self._singular_vectors2) / sqrt_expvar
 
@@ -169,27 +170,41 @@ class MCA(_BaseCrossModel):
         '''
         return self._singular_values
     
-    def explained_variance(self):
+    def explained_covariance(self):
         '''Get the explained covariance.
 
         The explained covariance corresponds to the singular values of the covariance matrix. Each singular value 
         represents the amount of variance explained by the corresponding mode in the data.
             
         '''
-        return self._explained_variance
+        return self._explained_covariance
     
+    def covariance_fraction(self):
+        '''Get the covariance fraction (CF).
+        
+        The covariance fraction is the proportion of the total covariance explained by each mode `i`. It is computed
+        as follows:
+        
+        .. math::
+        CF_i = \\frac{\\sigma_i}{\\sum_{i=1}^{m} \\sigma_i}
+
+        where `m` is the total number of modes and :math:`\\sigma_i` is the `ith` singular value of the covariance matrix.
+        
+        '''
+        cf = self._explained_covariance / self._total_covariance
+        cf.name = 'covariance_fraction'
+        return cf
+
     def squared_covariance_fraction(self):
         '''Calculate the squared covariance fraction (SCF).
 
-        The SCF is a measure of the proportion of the total covariance that is explained by each mode `i`. It is computed 
+        The SCF is a measure of the proportion of the total squared covariance that is explained by each mode `i`. It is computed 
         as follows:
 
         .. math::
         SCF_i = \\frac{\\sigma_i^2}{\\sum_{i=1}^{m} \\sigma_i^2}
 
         where `m` is the total number of modes and :math:`\\sigma_i` is the `ith` singular value of the covariance matrix.
-
-        The SCF is the analogue of the explained variance ratio in PCA.
 
         '''
         return self._squared_covariance_fraction
@@ -359,9 +374,9 @@ class MCA(_BaseCrossModel):
                 print('Singular values...')        
                 self._singular_values = self._singular_values.compute()
                 print('Explained variance...')
-                self._explained_variance = self._explained_variance.compute()
+                self._explained_covariance = self._explained_covariance.compute()
                 print('Squared total variance...')
-                self._squared_total_variance = self._squared_total_variance.compute()
+                self._total_squared_covariance = self._total_squared_covariance.compute()
                 print('Squared covariance fraction...')
                 self._squared_covariance_fraction = self._squared_covariance_fraction.compute()
                 print('Singular vectors...')
@@ -376,8 +391,8 @@ class MCA(_BaseCrossModel):
         
         else:
             self._singular_values = self._singular_values.compute()
-            self._explained_variance = self._explained_variance.compute()
-            self._squared_total_variance = self._squared_total_variance.compute()
+            self._explained_covariance = self._explained_covariance.compute()
+            self._total_squared_covariance = self._total_squared_covariance.compute()
             self._squared_covariance_fraction = self._squared_covariance_fraction.compute()
             self._singular_vectors1 = self._singular_vectors1.compute()
             self._singular_vectors2 = self._singular_vectors2.compute()
@@ -390,8 +405,8 @@ class MCA(_BaseCrossModel):
         '''Assign analysis-relevant meta data.'''
 
         self._singular_values.attrs.update(self.attrs)
-        self._explained_variance.attrs.update(self.attrs)
-        self._squared_total_variance.attrs.update(self.attrs)
+        self._explained_covariance.attrs.update(self.attrs)
+        self._total_squared_covariance.attrs.update(self.attrs)
         self._squared_covariance_fraction.attrs.update(self.attrs)
         self._singular_vectors1.attrs.update(self.attrs)
         self._singular_vectors2.attrs.update(self.attrs)
@@ -483,23 +498,24 @@ class ComplexMCA(MCA):
         # singular_values_pca is equivalent to the singular values obtained
         # when performing PCA of X1 or X2.
         self._singular_values = decomposer.singular_values_
-        self._explained_variance = decomposer.singular_values_  # actually covariance
-        self._squared_total_variance = decomposer.squared_total_variance_
-        self._squared_covariance_fraction = self._explained_variance**2 / self._squared_total_variance
+        self._explained_covariance = decomposer.singular_values_  # actually covariance
+        self._total_covariance = decomposer.total_covariance_
+        self._total_squared_covariance = decomposer.total_squared_covariance_
+        self._squared_covariance_fraction = self._explained_covariance**2 / self._total_squared_covariance
         self._singular_values_pca = np.sqrt(self._singular_values * (self.data1.shape[0] - 1))
         self._singular_vectors1 = decomposer.singular_vectors1_
         self._singular_vectors2 = decomposer.singular_vectors2_
         self._norm1 = np.sqrt(self._singular_values)
         self._norm2 = np.sqrt(self._singular_values)
 
-        self._explained_variance.name = 'explained_variance'
-        self._squared_total_variance.name = 'squared_total_variance'
+        self._explained_covariance.name = 'explained_variance'
+        self._total_squared_covariance.name = 'squared_total_variance'
         self._squared_covariance_fraction.name = 'squared_covariance_fraction'
         self._norm1.name = 'left_norm'
         self._norm2.name = 'right_norm'
 
         # Project the data onto the singular vectors
-        sqrt_expvar = np.sqrt(self._explained_variance)
+        sqrt_expvar = np.sqrt(self._explained_covariance)
         self._scores1 = xr.dot(self.data1, self._singular_vectors1) / sqrt_expvar
         self._scores2 = xr.dot(self.data2, self._singular_vectors2) / sqrt_expvar
 

--- a/xeofs/models/mca_rotator.py
+++ b/xeofs/models/mca_rotator.py
@@ -134,8 +134,14 @@ class MCARotator(_BaseRotator):
         scores1 = self._model._scores1.sel(mode=slice(1,n_modes))
         scores2 = self._model._scores2.sel(mode=slice(1,n_modes))
         R = self._get_rotation_matrix(inverse_transpose=True)
-        scores1 = xr.dot(scores1, R, dims='mode1')
-        scores2 = xr.dot(scores2, R, dims='mode1')
+
+        # The following renaming is necessary to ensure that the output dimension is `mode`
+        scores1 = xr.dot(scores1, R, dims='mode')
+        scores2 = xr.dot(scores2, R, dims='mode')
+        scores1 = scores1.assign_coords({'mode1': np.arange(1, n_modes + 1)})
+        scores2 = scores2.assign_coords({'mode1': np.arange(1, n_modes + 1)})
+        scores1 = scores1.rename({'mode1': 'mode'})
+        scores2 = scores2.rename({'mode1': 'mode'})
 
         # Reorder scores according to variance
         scores1 = scores1.isel(mode=idx_sort).assign_coords(mode=scores1.mode)

--- a/xeofs/models/mca_rotator.py
+++ b/xeofs/models/mca_rotator.py
@@ -121,8 +121,9 @@ class MCARotator(_BaseRotator):
         idx_sort = expvar.values.argsort()[::-1]
         self._idx_expvar = idx_sort
         
-        self._explained_variance = expvar.isel(mode=idx_sort).assign_coords(mode=expvar.mode)
-        self._squared_covariance_fraction = self._explained_variance ** 2 / self._model._squared_total_variance
+        self._explained_covariance = expvar.isel(mode=idx_sort).assign_coords(mode=expvar.mode)
+        self._covariance_fraction = self._explained_covariance / self._model._total_covariance
+        self._squared_covariance_fraction = self._explained_covariance ** 2 / self._model._total_squared_covariance
 
         self._norm1 = norm1.isel(mode=idx_sort).assign_coords(mode=norm1.mode)
         self._norm2 = norm2.isel(mode=idx_sort).assign_coords(mode=norm2.mode)
@@ -189,7 +190,7 @@ class MCARotator(_BaseRotator):
             raise ValueError('No data provided. Please provide data1 and/or data2.')
     
         n_modes = self._params['n_modes']
-        expvar = self._explained_variance.sel(mode=slice(1, self._params['n_modes']))
+        expvar = self._explained_covariance.sel(mode=slice(1, self._params['n_modes']))
         rot_matrix = self._get_rotation_matrix(inverse_transpose=True)
 
         results = []
@@ -284,7 +285,29 @@ class MCARotator(_BaseRotator):
         data2 = self._model.scaler2.inverse_transform(data2)  # type: ignore
 
         return data1, data2
+
+    def covariance_fraction(self) -> DataArray | Dataset | DataArrayList:
+        '''Return the covariance fraction (CF) of the rotated modes.
+
+        Returns
+        -------
+        xr.DataArray
+            Covariance fraction of the rotated modes.
+
+        '''
+        return self._covariance_fraction
     
+    def squared_covariance_fraction(self) -> DataArray | Dataset | DataArrayList:
+        '''Return the squared covariance fraction (SCF) of the rotated modes.
+
+        Returns
+        -------
+        xr.DataArray
+            Squared covariance fraction of the rotated modes.
+
+        '''
+        return self._squared_covariance_fraction
+
     def compute(self, verbose: bool = False):
         '''Compute the rotated solution.
         
@@ -301,7 +324,7 @@ class MCARotator(_BaseRotator):
                 print('Computing ROTATED MODEL...')
                 print('-'*80)
                 print('Explainned variance...')
-                self._explained_variance = self._explained_variance.compute()
+                self._explained_covariance = self._explained_covariance.compute()
                 print('Squared covariance fraction...')
                 self._squared_covariance_fraction = self._squared_covariance_fraction.compute()
                 print('Norms...')
@@ -316,7 +339,7 @@ class MCARotator(_BaseRotator):
                 self._scores1 = self._scores1.compute()
                 self._scores2 = self._scores2.compute()
         else:
-            self._explained_variance = self._explained_variance.compute()
+            self._explained_covariance = self._explained_covariance.compute()
             self._squared_covariance_fraction = self._squared_covariance_fraction.compute()
             self._norm1 = self._norm1.compute()
             self._norm2 = self._norm2.compute()
@@ -332,7 +355,7 @@ class MCARotator(_BaseRotator):
         attrs = self._model.attrs.copy()
         # Include meta data of the rotation
         attrs.update(self.attrs)
-        self._explained_variance.attrs.update(attrs)
+        self._explained_covariance.attrs.update(attrs)
         self._squared_covariance_fraction.attrs.update(attrs)
         self._singular_vectors1.attrs.update(attrs)
         self._singular_vectors2.attrs.update(attrs)


### PR DESCRIPTION
- fix erroneous dot product when computing scores (closes #65 ) credits to @mschulzie
- add conjugate when computing total squared covariance in CrossDecomposer (closes #64 ) @mschulzie
- streamline covariance and squared covariance fraction for MCA