### PR TITLE
chore(release): bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xeofs"
-version = "1.0.3"
+version = "1.0.4"
 description = "Collection of EOF analysis and related techniques for climate science"
 authors = ["Niclas Rieger <niclasrieger@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
last release did not trigger PSR action to publish to PyPI. Therefore version number lags behid the release number. To resolve PSR error bump version by hand.