### PR TITLE
build: add ipykernel as dependency

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - seaborn
   - cartopy
   - ipython
+  - ipykernel
   - pip:
     - pydata-sphinx-theme
     - sphinx-gallery


### PR DESCRIPTION
Include ipykernel in the doc environment which is required to build documentation on readthedocs