### PR TITLE
fix: safe default zarr write mode

### DIFF
--- a/xeofs/models/_base_cross_model.py
+++ b/xeofs/models/_base_cross_model.py
@@ -284,6 +284,7 @@ class _BaseCrossModel(ABC):
     def save(
         self,
         path: str,
+        overwrite: bool = False,
         save_data: bool = False,
         **kwargs,
     ):
@@ -293,6 +294,8 @@ class _BaseCrossModel(ABC):
         ----------
         path : str
             Path to save the model zarr store.
+        overwrite: bool, default=False
+            Whether or not to overwrite the existing path if it already exists.
         save_data : str
             Whether or not to save the full input data along with the fitted components.
         **kwargs
@@ -306,7 +309,9 @@ class _BaseCrossModel(ABC):
         if hasattr(self, "model"):
             dt["model"] = self.model.serialize()
 
-        dt.to_zarr(path, **kwargs)
+        write_mode = "w" if overwrite else "w-"
+
+        dt.to_zarr(path, mode=write_mode, **kwargs)
 
     @classmethod
     def deserialize(cls, dt: DataTree) -> Self:

--- a/xeofs/models/_base_model.py
+++ b/xeofs/models/_base_model.py
@@ -357,6 +357,7 @@ class _BaseModel(ABC):
     def save(
         self,
         path: str,
+        overwrite: bool = False,
         save_data: bool = False,
         **kwargs,
     ):
@@ -366,6 +367,8 @@ class _BaseModel(ABC):
         ----------
         path : str
             Path to save the model zarr store.
+        overwrite: bool, default=False
+            Whether or not to overwrite the existing path if it already exists.
         save_data : str
             Whether or not to save the full input data along with the fitted components.
         **kwargs
@@ -379,7 +382,9 @@ class _BaseModel(ABC):
         if hasattr(self, "model"):
             dt["model"] = self.model.serialize(save_data=save_data)
 
-        dt.to_zarr(path, **kwargs)
+        write_mode = "w" if overwrite else "w-"
+
+        dt.to_zarr(path, mode=write_mode, **kwargs)
 
     @classmethod
     def deserialize(cls, dt: DataTree) -> Self:


### PR DESCRIPTION
Closes #106. Figured this was clearer than directly passing through a default `mode` kwarg, since I can't imagine ever wanting to use 'a' or 'r+' here.