### PR TITLE
fix: remove xarray-datatree from poetry.group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3160,4 +3160,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "d6a8f52cdfedd044cf44cd017d5cf8d802c180f9355b9e3fd1007e2b06f7abdc"
+content-hash = "b484f975356afb641449626a4e6fd1dcd7f2a10f5aa3573b321d0d4334e52fdd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,6 @@ statsmodels = ">=0.14.0"
 netCDF4 = "^1.5.7"
 numba = "^0.57"
 typing-extensions = "^4.8.0"
-
-
-[tool.poetry.group.io]
-optional = false
-
-[tool.poetry.group.io.dependencies]
 zarr = ">=2.0.0"
 xarray-datatree = ">=0.0.5"
 


### PR DESCRIPTION
poetry.groups are not installed by pip. This fix adds
xarray-datatree to the main dependency group in
pyproject.toml (fixes #112)