### PR TITLE
fix: only sort transform if model is already sorted

### DIFF
--- a/xeofs/models/eof_rotator.py
+++ b/xeofs/models/eof_rotator.py
@@ -242,9 +242,10 @@ class EOFRotator(EOF):
         projections = xr.dot(projections, RinvT, dims="mode_m")
         # Reorder according to variance
         # this must be done in one line: i) select modes according to their variance, ii) replace coords with modes from 1 ... n
-        projections = projections.isel(
-            mode=self.data["idx_modes_sorted"].values
-        ).assign_coords(mode=projections.mode)
+        if self.sorted:
+            projections = projections.isel(
+                mode=self.data["idx_modes_sorted"].values
+            ).assign_coords(mode=projections.mode)
 
         # Scale scores by "pseudo" norms
         projections = projections * pseudo_norms

--- a/xeofs/models/mca_rotator.py
+++ b/xeofs/models/mca_rotator.py
@@ -363,9 +363,10 @@ class MCARotator(MCA):
             projections1 = projections1.rename({"mode": "mode_m"})
             projections1 = xr.dot(projections1, RinvT, dims="mode_m")
             # Reorder according to variance
-            projections1 = projections1.isel(
-                mode=self.data["idx_modes_sorted"].values
-            ).assign_coords(mode=projections1.mode)
+            if self.sorted:
+                projections1 = projections1.isel(
+                    mode=self.data["idx_modes_sorted"].values
+                ).assign_coords(mode=projections1.mode)
             # Adapt the sign of the scores
             projections1 = projections1 * self.data["modes_sign"]
 
@@ -389,9 +390,10 @@ class MCARotator(MCA):
             projections2 = projections2.rename({"mode": "mode_m"})
             projections2 = xr.dot(projections2, RinvT, dims="mode_m")
             # Reorder according to variance
-            projections2 = projections2.isel(
-                mode=self.data["idx_modes_sorted"].values
-            ).assign_coords(mode=projections2.mode)
+            if self.sorted:
+                projections2 = projections2.isel(
+                    mode=self.data["idx_modes_sorted"].values
+                ).assign_coords(mode=projections2.mode)
             # Determine the sign of the scores
             projections2 = projections2 * self.data["modes_sign"]
 


### PR DESCRIPTION
I was having trouble round-tripping properly when doing things in lazy mode without explicitly calling `.compute()`. Realized it was because in `transform()` the modes were getting sorted by variance regardless of whether the model itself was sorted.