### PR TITLE
feat: support saving to netcdf

### DIFF
--- a/tests/models/test_eof.py
+++ b/tests/models/test_eof.py
@@ -480,7 +480,8 @@ def test_inverse_transform(dim, mock_data_array):
         (("lon", "lat")),
     ],
 )
-def test_save_load(dim, mock_data_array, tmp_path):
+@pytest.mark.parametrize("engine", ["netcdf4", "zarr"])
+def test_save_load(dim, mock_data_array, tmp_path, engine):
     """Test save/load methods in EOF class, ensuring that we can
     roundtrip the model and get the same results when transforming
     data."""
@@ -488,13 +489,13 @@ def test_save_load(dim, mock_data_array, tmp_path):
     original.fit(mock_data_array, dim)
 
     # Save the EOF model
-    original.save(tmp_path / "eof.zarr")
+    original.save(tmp_path / "eof", engine=engine)
 
     # Check that the EOF model has been saved
-    assert (tmp_path / "eof.zarr").exists()
+    assert (tmp_path / "eof").exists()
 
     # Recreate the model from saved file
-    loaded = EOF.load(tmp_path / "eof.zarr")
+    loaded = EOF.load(tmp_path / "eof", engine=engine)
 
     # Check that the params and DataContainer objects match
     assert original.get_params() == loaded.get_params()

--- a/tests/models/test_eof_rotator.py
+++ b/tests/models/test_eof_rotator.py
@@ -203,7 +203,8 @@ def test_compute(eof_model_delayed, compute):
         (("lon", "lat")),
     ],
 )
-def test_save_load(dim, mock_data_array, tmp_path):
+@pytest.mark.parametrize("engine", ["netcdf4", "zarr"])
+def test_save_load(dim, mock_data_array, tmp_path, engine):
     """Test save/load methods in EOF class, ensuring that we can
     roundtrip the model and get the same results when transforming
     data."""
@@ -214,13 +215,13 @@ def test_save_load(dim, mock_data_array, tmp_path):
     original.fit(original_unrotated)
 
     # Save the EOF model
-    original.save(tmp_path / "eof.zarr")
+    original.save(tmp_path / "eof", engine=engine)
 
     # Check that the EOF model has been saved
-    assert (tmp_path / "eof.zarr").exists()
+    assert (tmp_path / "eof").exists()
 
     # Recreate the model from saved file
-    loaded = EOFRotator.load(tmp_path / "eof.zarr")
+    loaded = EOFRotator.load(tmp_path / "eof", engine=engine)
 
     # Check that the params and DataContainer objects match
     assert original.get_params() == loaded.get_params()

--- a/tests/models/test_mca.py
+++ b/tests/models/test_mca.py
@@ -393,7 +393,8 @@ def test_compute(mock_dask_data_array, dim, compute):
         (("lon", "lat")),
     ],
 )
-def test_save_load(dim, mock_data_array, tmp_path):
+@pytest.mark.parametrize("engine", ["netcdf4", "zarr"])
+def test_save_load(dim, mock_data_array, tmp_path, engine):
     """Test save/load methods in MCA class, ensuring that we can
     roundtrip the model and get the same results when transforming
     data."""
@@ -401,13 +402,13 @@ def test_save_load(dim, mock_data_array, tmp_path):
     original.fit(mock_data_array, mock_data_array, dim)
 
     # Save the EOF model
-    original.save(tmp_path / "mca.zarr")
+    original.save(tmp_path / "mca", engine=engine)
 
     # Check that the EOF model has been saved
-    assert (tmp_path / "mca.zarr").exists()
+    assert (tmp_path / "mca").exists()
 
     # Recreate the model from saved file
-    loaded = MCA.load(tmp_path / "mca.zarr")
+    loaded = MCA.load(tmp_path / "mca", engine=engine)
 
     # Check that the params and DataContainer objects match
     assert original.get_params() == loaded.get_params()

--- a/tests/models/test_mca_rotator.py
+++ b/tests/models/test_mca_rotator.py
@@ -262,7 +262,8 @@ def test_compute(mca_model_delayed, compute):
         (("lon", "lat")),
     ],
 )
-def test_save_load(dim, mock_data_array, tmp_path):
+@pytest.mark.parametrize("engine", ["netcdf4", "zarr"])
+def test_save_load(dim, mock_data_array, tmp_path, engine):
     """Test save/load methods in MCA class, ensuring that we can
     roundtrip the model and get the same results when transforming
     data."""
@@ -273,13 +274,13 @@ def test_save_load(dim, mock_data_array, tmp_path):
     original.fit(original_unrotated)
 
     # Save the EOF model
-    original.save(tmp_path / "mca.zarr")
+    original.save(tmp_path / "mca", engine=engine)
 
     # Check that the EOF model has been saved
-    assert (tmp_path / "mca.zarr").exists()
+    assert (tmp_path / "mca").exists()
 
     # Recreate the model from saved file
-    loaded = MCARotator.load(tmp_path / "mca.zarr")
+    loaded = MCARotator.load(tmp_path / "mca", engine=engine)
 
     # Check that the params and DataContainer objects match
     assert original.get_params() == loaded.get_params()

--- a/xeofs/models/_base_cross_model.py
+++ b/xeofs/models/_base_cross_model.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Hashable, Sequence, Dict, Optional, List
+from typing import Tuple, Hashable, Sequence, Dict, Optional, List, Literal
 from typing_extensions import Self
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -6,13 +6,14 @@ from datetime import datetime
 import dask
 import numpy as np
 import xarray as xr
-from datatree import DataTree, open_datatree
+from datatree import DataTree
 from dask.diagnostics.progress import ProgressBar
 
 from .eof import EOF
 from ..preprocessing.preprocessor import Preprocessor
 from ..data_container import DataContainer
 from ..utils.data_types import DataObject, DataArray, DataSet
+from ..utils.io import insert_placeholders, open_model_tree, write_model_tree
 from ..utils.xarray_utils import convert_to_dim_type, data_is_dask
 from ..utils.sanity_checks import validate_input_type
 from .._version import __version__
@@ -335,20 +336,24 @@ class _BaseCrossModel(ABC):
         path: str,
         overwrite: bool = False,
         save_data: bool = False,
+        engine: Literal["zarr", "netcdf4", "h5netcdf"] = "zarr",
         **kwargs,
     ):
-        """Save the model to zarr.
+        """Save the model.
 
         Parameters
         ----------
         path : str
-            Path to save the model zarr store.
+            Path to save the model.
         overwrite: bool, default=False
             Whether or not to overwrite the existing path if it already exists.
+            Ignored unless `engine="zarr"`.
         save_data : str
             Whether or not to save the full input data along with the fitted components.
+        engine : {"zarr", "netcdf4", "h5netcdf"}, default="zarr"
+            Xarray backend engine to use for writing the saved model.
         **kwargs
-            Additional keyword arguments to pass to `DataTree.to_zarr()`.
+            Additional keyword arguments to pass to `DataTree.to_netcdf()` or `DataTree.to_zarr()`.
 
         """
         self.compute()
@@ -356,19 +361,10 @@ class _BaseCrossModel(ABC):
         dt = self.serialize()
 
         # Remove any raw data arrays at this stage
-        for node in dt.subtree:
-            if not node.attrs.get("allow_compute", True) and not save_data:
-                dt[node.path] = DataTree(
-                    xr.Dataset(
-                        data_vars={
-                            node.name: xr.DataArray(np.nan, attrs={"placeholder": True})
-                        },
-                        attrs={"allow_compute": False, "placeholder": True},
-                    )
-                )
+        if not save_data:
+            dt = insert_placeholders(dt)
 
-        write_mode = "w" if overwrite else "w-"
-        dt.to_zarr(path, mode=write_mode, **kwargs)
+        write_model_tree(dt, path, overwrite=overwrite, engine=engine, **kwargs)
 
     @classmethod
     def deserialize(cls, dt: DataTree) -> Self:
@@ -390,13 +386,20 @@ class _BaseCrossModel(ABC):
             setattr(self, key, deserialized_obj)
 
     @classmethod
-    def load(cls, path: str, **kwargs) -> Self:
-        """Load a saved model from zarr.
+    def load(
+        cls,
+        path: str,
+        engine: Literal["zarr", "netcdf4", "h5netcdf"] = "zarr",
+        **kwargs,
+    ) -> Self:
+        """Load a saved model.
 
         Parameters
         ----------
         path : str
-            Path to the saved model zarr store.
+            Path to the saved model.
+        engine : {"zarr", "netcdf4", "h5netcdf"}, default="zarr"
+            Xarray backend engine to use for reading the saved model.
         **kwargs
             Additional keyword arguments to pass to `open_datatree()`.
 
@@ -406,7 +409,7 @@ class _BaseCrossModel(ABC):
             The loaded model.
 
         """
-        dt = open_datatree(path, engine="zarr", **kwargs)
+        dt = open_model_tree(path, engine=engine, **kwargs)
         model = cls.deserialize(dt)
         return model
 

--- a/xeofs/models/_base_model.py
+++ b/xeofs/models/_base_model.py
@@ -6,6 +6,7 @@ from typing import (
     Dict,
     Any,
     List,
+    Literal,
     TypeVar,
     Tuple,
 )
@@ -16,12 +17,13 @@ from datetime import datetime
 import dask
 import numpy as np
 import xarray as xr
-from datatree import DataTree, open_datatree
+from datatree import DataTree
 from dask.diagnostics.progress import ProgressBar
 
 from ..preprocessing.preprocessor import Preprocessor
 from ..data_container import DataContainer
 from ..utils.data_types import DataObject, Data, DataArray, DataSet, DataList, Dims
+from ..utils.io import insert_placeholders, open_model_tree, write_model_tree
 from ..utils.sanity_checks import validate_input_type
 from ..utils.xarray_utils import (
     convert_to_dim_type,
@@ -401,20 +403,24 @@ class _BaseModel(ABC):
         path: str,
         overwrite: bool = False,
         save_data: bool = False,
+        engine: Literal["zarr", "netcdf4", "h5netcdf"] = "zarr",
         **kwargs,
     ):
-        """Save the model to zarr.
+        """Save the model.
 
         Parameters
         ----------
         path : str
-            Path to save the model zarr store.
+            Path to save the model.
         overwrite: bool, default=False
             Whether or not to overwrite the existing path if it already exists.
+            Ignored unless `engine="zarr"`.
         save_data : str
             Whether or not to save the full input data along with the fitted components.
+        engine : {"zarr", "netcdf4", "h5netcdf"}, default="zarr"
+            Xarray backend engine to use for writing the saved model.
         **kwargs
-            Additional keyword arguments to pass to `DataTree.to_zarr()`.
+            Additional keyword arguments to pass to `DataTree.to_netcdf()` or `DataTree.to_zarr()`.
 
         """
         self.compute()
@@ -422,19 +428,10 @@ class _BaseModel(ABC):
         dt = self.serialize()
 
         # Remove any raw data arrays at this stage
-        for node in dt.subtree:
-            if not node.attrs.get("allow_compute", True) and not save_data:
-                dt[node.path] = DataTree(
-                    xr.Dataset(
-                        data_vars={
-                            node.name: xr.DataArray(np.nan, attrs={"placeholder": True})
-                        },
-                        attrs={"allow_compute": False, "placeholder": True},
-                    )
-                )
+        if not save_data:
+            dt = insert_placeholders(dt)
 
-        write_mode = "w" if overwrite else "w-"
-        dt.to_zarr(path, mode=write_mode, **kwargs)
+        write_model_tree(dt, path, overwrite=overwrite, engine=engine, **kwargs)
 
     @classmethod
     def deserialize(cls, dt: DataTree) -> Self:
@@ -456,13 +453,20 @@ class _BaseModel(ABC):
             setattr(self, key, deserialized_obj)
 
     @classmethod
-    def load(cls, path: str, **kwargs) -> Self:
-        """Load a saved model from zarr.
+    def load(
+        cls,
+        path: str,
+        engine: Literal["zarr", "netcdf4", "h5netcdf"] = "zarr",
+        **kwargs,
+    ) -> Self:
+        """Load a saved model.
 
         Parameters
         ----------
         path : str
-            Path to the saved model zarr store.
+            Path to the saved model.
+        engine : {"zarr", "netcdf4", "h5netcdf"}, default="zarr"
+            Xarray backend engine to use for reading the saved model.
         **kwargs
             Additional keyword arguments to pass to `open_datatree()`.
 
@@ -472,7 +476,7 @@ class _BaseModel(ABC):
             The loaded model.
 
         """
-        dt = open_datatree(path, engine="zarr", **kwargs)
+        dt = open_model_tree(path, engine=engine, **kwargs)
         model = cls.deserialize(dt)
         return model
 

--- a/xeofs/utils/io.py
+++ b/xeofs/utils/io.py
@@ -1,0 +1,82 @@
+from ast import literal_eval
+from typing import Any
+
+import numpy as np
+import xarray as xr
+from datatree import DataTree, open_datatree
+
+
+def write_model_tree(
+    dt: DataTree, path: str, overwrite: bool = False, engine: str = "zarr", **kwargs
+):
+    """Write a DataTree to a file."""
+    write_mode = "w" if overwrite else "w-"
+    if engine in ["netcdf4", "h5netcdf"]:
+        dt = _sanitize_attrs_nc(dt)
+        dt.to_netcdf(path, engine=engine, **kwargs)
+    elif engine == "zarr":
+        dt.to_zarr(path, mode=write_mode, **kwargs)
+    else:
+        raise ValueError(f"Unknown engine {engine}")
+
+
+def open_model_tree(path: str, engine: str = "zarr", chunks={}, **kwargs) -> DataTree:
+    """Open a DataTree from a file."""
+    dt = open_datatree(path, engine=engine, chunks=chunks, **kwargs)
+    if engine in ["netcdf4", "h5netcdf"]:
+        dt = _desanitize_attrs_nc(dt)
+    return dt
+
+
+def insert_placeholders(dt: DataTree) -> DataTree:
+    """Insert placeholders for data that we don't want to compute."""
+    for node in dt.subtree:
+        if not node.attrs.get("allow_compute", True):
+            dt[node.path] = DataTree(
+                xr.Dataset(
+                    data_vars={
+                        node.name: xr.DataArray(np.nan, attrs={"placeholder": True})
+                    },
+                    attrs={"allow_compute": False, "placeholder": True},
+                )
+            )
+    return dt
+
+
+def _sanitize_attrs_nc(dt: DataTree) -> DataTree:
+    """Sanitize both node-level and variable-level attrs to strings for netcdf."""
+    sanitized_types = (dict, list, bool, type(None))
+    for node in dt.subtree:
+        for key, attr in node.attrs.items():
+            if isinstance(attr, sanitized_types):
+                node.attrs[key] = str(attr)
+        for v in node.variables:
+            for key, attr in node[v].attrs.items():
+                if isinstance(attr, sanitized_types):
+                    node[v].attrs[key] = str(attr)
+    return dt
+
+
+def _should_desanitize(attr: Any) -> bool:
+    if isinstance(attr, str):
+        if (
+            (attr[0] == "{" and attr[-1] == "}")
+            or (attr[0] == "[" and attr[-1] == "]")
+            or (attr in ["True", "False"])
+            or (attr == "None")
+        ):
+            return True
+    return False
+
+
+def _desanitize_attrs_nc(dt: DataTree) -> DataTree:
+    """Desanitize both node-level and variable-level attrs from strings for netcdf."""
+    for node in dt.subtree:
+        for key, attr in node.attrs.items():
+            if _should_desanitize(attr):
+                node.attrs[key] = literal_eval(attr)
+        for v in node.variables:
+            for key, attr in node[v].attrs.items():
+                if _should_desanitize(attr):
+                    node[v].attrs[key] = literal_eval(attr)
+    return dt


### PR DESCRIPTION
Realized it's actually pretty easy to add support for netcdf serialization, despite the limitations on dtypes for attrs. We can just intelligently convert non-supported types to and from strings. Seemed worth adding this option since the DataTree zarr backend has some issues currently (e.g. [#277](https://github.com/xarray-contrib/datatree/issues/277)) and may be getting a rework eventually. I did leave the default as zarr.