### PR TITLE
fix: update to handle v8 semantic release GH action

### DIFF
--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -11,6 +11,9 @@ jobs:
   Release_Package:
     runs-on: ubuntu-latest
     concurrency: release
+    permissions:
+          id-token: write
+          contents: write
 
     steps:
       - name: Checkout Repository
@@ -18,9 +21,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Execute Semantic Release
-        uses: python-semantic-release/python-semantic-release@v7.34.6
+      # This action uses Python Semantic Release v8
+      - name: Python Semantic Release
+        id: release
+        uses: python-semantic-release/python-semantic-release@v8
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          repository_username: __token__
-          repository_password: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
+        # See https://github.com/actions/runner/issues/1173
+        if: steps.release.outputs.released == 'true'
+
+      - name: Publish package distributions to GitHub Releases
+        uses: python-semantic-release/upload-to-gh-release@main
+        if: steps.release.outputs.released == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Based on the most recent note on your issue @nicrie ([#654](https://github.com/python-semantic-release/python-semantic-release/issues/654#issuecomment-1736850729)) and the [migration guide](https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html), I think this might fix the first item of #126.