### PR TITLE
docs: single EOF scores default parameter normalized: False

### DIFF
--- a/xeofs/single/eof.py
+++ b/xeofs/single/eof.py
@@ -177,7 +177,7 @@ class EOF(BaseModelSingleSet):
 
         Parameters
         ----------
-        normalized : bool, default=True
+        normalized : bool, default=False
             Whether to normalize the scores by the L2 norm (singular values).
 
         Returns


### PR DESCRIPTION
Addresses https://github.com/xarray-contrib/xeofs/issues/241